### PR TITLE
Fix the events page failing to render, and half-finished saves

### DIFF
--- a/internal/events/event.go
+++ b/internal/events/event.go
@@ -74,8 +74,18 @@ type Attendance struct {
 	Registered time.Time `bson:"registered"`
 }
 
+// The accessors below take value receivers, not pointers, and that is
+// load-bearing rather than stylistic.
+//
+// Templates range over []Event, which yields values, and a value placed into a
+// map[string]any is boxed in an interface — which is not addressable. Go
+// templates cannot call a pointer-receiver method on a non-addressable value,
+// so every one of these would silently become unavailable and the page would
+// fail to render with "can't evaluate field". None of them mutate, so there is
+// nothing to gain from a pointer.
+
 // HexID renders the identifier for a URL or a form field.
-func (e *Event) HexID() string {
+func (e Event) HexID() string {
 	if e.ID.IsZero() {
 		return ""
 	}
@@ -83,28 +93,28 @@ func (e *Event) HexID() string {
 }
 
 // Past reports whether the event has finished.
-func (e *Event) Past() bool { return !e.End.IsZero() && e.End.Before(time.Now()) }
+func (e Event) Past() bool { return !e.End.IsZero() && e.End.Before(time.Now()) }
 
 // When renders the start time the way the site displays it.
-func (e *Event) When() string { return timefmt.Smart(e.Date) }
+func (e Event) When() string { return timefmt.Smart(e.Date) }
 
 // WhenISO renders the start time for a machine — the datetime attribute on a
 // <time> element.
-func (e *Event) WhenISO() string { return timefmt.ISO(e.Date) }
+func (e Event) WhenISO() string { return timefmt.ISO(e.Date) }
 
 // Attendees is the number of people checked in.
-func (e *Event) Attendees() int { return len(e.CheckIn.Attendances) }
+func (e Event) Attendees() int { return len(e.CheckIn.Attendances) }
 
 // HasCheckIn reports whether the event has a usable check-in code.
 //
 // The previous application seeded new events with the literal string "null"
 // before replacing it, so that value appears on disk and means "no code".
-func (e *Event) HasCheckIn() bool {
+func (e Event) HasCheckIn() bool {
 	return e.CheckIn.Code != "" && e.CheckIn.Code != "null"
 }
 
 // ComputeEnd derives the end time from the start and duration. Kept as a
 // method so the write path and the tests cannot disagree about it.
-func (e *Event) ComputeEnd() time.Time {
+func (e Event) ComputeEnd() time.Time {
 	return e.Date.Add(time.Duration(e.Duration * float64(time.Hour)))
 }

--- a/internal/events/service.go
+++ b/internal/events/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 
@@ -40,6 +41,26 @@ func NewService(repo Repository, syncer Syncer, log *slog.Logger) *Service {
 // operation that mostly worked.
 var ErrDiscordSync = errors.New("event saved, but Discord was not updated")
 
+// writeTimeout bounds a write that spans both Discord and the database.
+const writeTimeout = 20 * time.Second
+
+// detach returns a context that carries the deadline but not the cancellation
+// of its parent.
+//
+// A save touches two systems that cannot be rolled back together. Driving it
+// from the request context means a browser that gives up — a double-submitted
+// form, a closed tab, a flaky connection — cancels the operation wherever it
+// happens to be, and "context canceled" is what that looks like in the log.
+// The damage is not the failed request but the state it leaves: a Discord
+// event created whose identifier was never stored, so the next attempt creates
+// a second one and the first can no longer be reached.
+//
+// Once the work has started it runs to its own deadline. The visitor may never
+// see the outcome; the two systems still agree about it.
+func detach(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), writeTimeout)
+}
+
 // Save creates or updates an event.
 //
 // Fields the form must not control are carried over from the stored event
@@ -47,6 +68,9 @@ var ErrDiscordSync = errors.New("event saved, but Discord was not updated")
 // because it is printed on QR codes and reassigning it would invalidate every
 // one already handed out.
 func (s *Service) Save(ctx context.Context, id bson.ObjectID, in *Event) (bson.ObjectID, error) {
+	ctx, cancel := detach(ctx)
+	defer cancel()
+
 	var existing *Event
 	if !id.IsZero() {
 		var err error
@@ -126,6 +150,9 @@ func (s *Service) syncDiscord(ctx context.Context, e *Event) error {
 
 // Delete removes an event and its Discord counterpart.
 func (s *Service) Delete(ctx context.Context, id bson.ObjectID) error {
+	ctx, cancel := detach(ctx)
+	defer cancel()
+
 	existing, err := s.repo.ByID(ctx, id)
 	if err != nil {
 		return err

--- a/internal/web/eventcard_test.go
+++ b/internal/web/eventcard_test.go
@@ -1,0 +1,99 @@
+package web_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/ItemizeNTNU/website/assets"
+	"github.com/ItemizeNTNU/website/internal/events"
+	"github.com/ItemizeNTNU/website/internal/fusionauth"
+	"github.com/ItemizeNTNU/website/internal/httpx"
+	"github.com/ItemizeNTNU/website/internal/web"
+)
+
+// stubRepo returns a fixed list, so the events page actually renders cards.
+type stubRepo struct {
+	events.Repository
+	list []events.Event
+}
+
+func (s stubRepo) List(context.Context, events.Filter) ([]events.Event, error) {
+	return s.list, nil
+}
+
+// The event card was never exercised: every existing test ran with a nil
+// repository, which renders the "unavailable" branch and no cards at all. A
+// template error inside the card — a method that cannot be called, a renamed
+// field — therefore passed the whole suite and only appeared in production as
+// a 500.
+//
+// This renders a real card. It would have caught the pointer-receiver
+// regression, where boxing the value in a map made every accessor
+// unreachable and the page failed with "can't evaluate field Past".
+func TestEventCardRenders(t *testing.T) {
+	start := time.Now().Add(48 * time.Hour)
+	repo := stubRepo{list: []events.Event{{
+		ID:          bson.NewObjectID(),
+		Name:        "Pizza, øl og CTF",
+		Location:    events.Place{Name: "Savannen", URL: "https://use.mazemap.com/x"},
+		RegisterURL: "https://example.no/pamelding",
+		Date:        start,
+		Duration:    3,
+		End:         start.Add(3 * time.Hour),
+		CTF:         events.Place{Name: "picoCTF", URL: "https://play.picoctf.org"},
+		Info:        "Ta med laptop.\nVi starter 17:15.",
+		CheckIn:     events.CheckIn{Code: "3f8a1c2e-0000-4aaa-bbbb-ccccddddeeee"},
+	}}}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	fsys := assets.FS(false)
+	assetServer, err := httpx.NewAssets(fsys, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := web.NewServer(fsys, assetServer, repo, nil,
+		fusionauth.New("https://auth.example", ""), nil, "https://itemize.no", log, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	site.Routes(mux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/arrangementer", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 — the card template probably failed to execute", rec.Code)
+	}
+
+	body := rec.Body.String()
+	// Each of these comes from a different accessor, so a receiver or naming
+	// mistake in any one of them fails here rather than in production.
+	for _, want := range []string{
+		"Pizza, øl og CTF",          // Name
+		"Savannen",                  // Location
+		"https://use.mazemap.com/x", // Location.URL
+		"https://play.picoctf.org",  // CTF.URL
+		"Ta med laptop.",            // Info, escaped
+		`<time datetime="`,          // WhenISO
+		`class="event__info"`,       // the non-colliding class
+	} {
+		if !contains(body, want) {
+			t.Errorf("the rendered card is missing %q", want)
+		}
+	}
+
+	// Board-only controls must not appear for an anonymous visitor.
+	for _, forbidden := range []string{"/innsjekk/", "?rediger=", "3f8a1c2e-0000"} {
+		if contains(body, forbidden) {
+			t.Errorf("%q leaked to an anonymous visitor", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
Two faults behind the 500s on /arrangementer.

The page stopped rendering entirely
-----------------------------------
Every Event accessor took a pointer receiver. Templates range over []Event, which yields values, and passing one into dict boxes it in an interface — which is not addressable. Go templates cannot call a pointer-receiver method on a non-addressable value, so Past, When, WhenISO, HexID, Attendees and HasCheckIn all became unreachable at once and execution failed with "can't evaluate field Past in type events.Event".

This was a regression, not an original mistake: the card was passed the value directly until the admin controls needed a second argument, and the dict wrapper introduced the boxing. None of these methods mutate, so they are value receivers now and the whole class of failure goes away.

It reached production because the card had no test. Every existing case ran with a nil repository, which renders the "unavailable" branch and no cards at all — so a broken card template passed the entire suite. There is now a test with a stub repository that renders a real card and asserts against output from each accessor, plus that board-only controls and the check-in code stay out of an anonymous response. Reintroducing the pointer receiver fails it with the same 500.

Saves could be torn in half
---------------------------
The write path ran on the request context, so a browser that gave up — a double-submitted form, a closed tab, a flaky connection — cancelled the operation wherever it had got to. That is what "context canceled" was.

The failed request is not the damage. A save touches Discord and MongoDB, which cannot be rolled back together, so cancellation between them leaves a Discord event whose identifier was never stored: unreachable, and duplicated by the next attempt. Saves and deletes now run on a context that inherits the deadline but not the cancellation, bounded at twenty seconds. The visitor may not see the outcome; the two systems still agree on it.