### PR TITLE
Open dependency updates against dev instead of main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,17 @@
 # the repository's history is otherwise dominated by one-at-a-time
 # "Bump X from A to B". Major versions still arrive on their own, so somebody
 # actually reads them.
+#
+# Updates open against dev rather than main, so they land where the rest of the
+# work does and reach main through the usual pull request. Dependabot reads this
+# file from the default branch regardless, so target-branch has to be set here
+# on main to take effect. Security updates are exempt and still arrive on main.
 version: 2
 
 updates:
   - package-ecosystem: gomod
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -24,11 +30,13 @@ updates:
 
   - package-ecosystem: docker
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
Routes Dependabot version updates to `dev` so they land where the rest of the work does and reach `main` through the usual pull request.

`target-branch: dev` is set on all three ecosystems (gomod, docker, github-actions). Dependabot reads `dependabot.yml` from the default branch regardless of where the pull requests go, which is why the setting has to live on `main`.

One caveat worth knowing: `target-branch` covers version updates only. Security updates are still raised against the default branch, so those will keep appearing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)